### PR TITLE
Transfer build changes from EH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(REViewer)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Check for required packages:
+find_package(ZLIB REQUIRED)
+find_package(BZip2 REQUIRED)
+find_package(LibLZMA REQUIRED)
+
 include(ExternalProject)
 
 set(installDir ${CMAKE_CURRENT_BINARY_DIR}/install)
@@ -11,48 +16,64 @@ set(installDir ${CMAKE_CURRENT_BINARY_DIR}/install)
 
 ExternalProject_Add(htslib
 	BUILD_IN_SOURCE YES
-	GIT_REPOSITORY "https://github.com/samtools/htslib.git"
-	GIT_TAG "1.10.2"
-	UPDATE_COMMAND ""
-	CONFIGURE_COMMAND ""
-	BUILD_COMMAND make
-	INSTALL_COMMAND make install prefix=${installDir}
-	LOG_DOWNLOAD YES
+	URL https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2
+	CONFIGURE_COMMAND ./configure --prefix=${installDir} --disable-libcurl
+	BUILD_COMMAND $(MAKE) lib-static
 )
 
+
+# Setup boost user config so that it uses the same c++ compiler as other components:
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+	set (BOOST_COMPILER_TAG "gcc")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	set (BOOST_COMPILER_TAG "clang")
+	set(B2_OPTIONS ${B2_OPTIONS} "toolset=clang")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+	set (BOOST_COMPILER_TAG "darwin")
+	set(B2_OPTIONS ${B2_OPTIONS} "toolset=clang")
+endif()
+
+if (BOOST_COMPILER_TAG)
+	set(BOOST_UCONFIG "${CMAKE_BINARY_DIR}/user-config.jam")
+	file(WRITE "${BOOST_UCONFIG}" "using ${BOOST_COMPILER_TAG} : : \"${CMAKE_CXX_COMPILER}\" ;\n")
+	set(BOOST_PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${BOOST_UCONFIG} tools/build/src/user-config.jam)
+endif()
 
 ExternalProject_Add(Boost
 	BUILD_IN_SOURCE YES
 	URL https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2
-	UPDATE_COMMAND ""
-	CONFIGURE_COMMAND ./bootstrap.sh --prefix=${installDir}/lib
-	BUILD_COMMAND ./b2 install -j8   --prefix=${installDir} --with-filesystem --with-system --with-program_options link=static,shared
+	PATCH_COMMAND ${BOOST_PATCH_COMMAND}
+	CONFIGURE_COMMAND ./bootstrap.sh --prefix=${installDir}
+	BUILD_COMMAND ./b2 install -j8 --with-filesystem --with-system --with-program_options link=static ${B2_OPTIONS}
 	INSTALL_COMMAND ""
 )
 
 
 ExternalProject_Add(spdlog
-	GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
-	GIT_TAG "v1.6.1"
-	UPDATE_COMMAND ""
+	URL https://github.com/gabime/spdlog/archive/refs/tags/v1.6.1.tar.gz
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${installDir}
+		-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+		-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
 )
 
 
 ExternalProject_Add(catch2
-	GIT_REPOSITORY "https://github.com/catchorg/Catch2.git"
-	GIT_TAG "v2.12.4"
-	UPDATE_COMMAND ""
+	URL https://github.com/catchorg/Catch2/archive/refs/tags/v2.12.4.tar.gz
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${installDir}
-	           -DBUILD_TESTING=OFF
+		-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+		-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+		-DBUILD_TESTING=OFF
 )
 
 
 ExternalProject_Add(reviewer
 	SOURCE_DIR ${CMAKE_SOURCE_DIR}/reviewer
 	BUILD_ALWAYS YES
-	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${installDir}
-		   -DCMAKE_PREFIX_PATH:PATH=${installDir}
+	CMAKE_ARGS
+		-DCMAKE_INSTALL_PREFIX:PATH=${installDir}
+		-DCMAKE_PREFIX_PATH:PATH=${installDir}
+		-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+		-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
 )
 
 

--- a/reviewer/CMakeLists.txt
+++ b/reviewer/CMakeLists.txt
@@ -1,8 +1,14 @@
 cmake_minimum_required(VERSION 3.7)
-project(REViewer VERSION 0.2.4 LANGUAGES C CXX)
+project(REViewer VERSION 0.2.4 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if (NOT CMAKE_BUILD_TYPE)
+    set(DEFAULT_CMAKE_BUILD_TYPE Release)
+    set(CMAKE_BUILD_TYPE ${DEFAULT_CMAKE_BUILD_TYPE} CACHE STRING
+            "Choose the type of build (default: ${DEFAULT_CMAKE_BUILD_TYPE})" FORCE)
+endif ()
 
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost 1.73 REQUIRED COMPONENTS program_options filesystem system)
@@ -49,7 +55,14 @@ target_include_directories(REViewer PUBLIC
         ${LIBLZMA_INCLUDE_DIRS}
         ${CURL_INCLUDE_DIRS}
         )
+
+# Set static linking of gcc standard libraries to simplify binary distribution
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(STATIC_FLAGS -static-libgcc -static-libstdc++)
+endif()
+
 target_link_libraries(REViewer PUBLIC
+        ${STATIC_FLAGS}
         graphtools
         ${htslib}
         ${Boost_LIBRARIES}


### PR DESCRIPTION
These changes are mostly intended to allow an alternate CC/CXX compiler at
cmake configuration time, in particular for cases which cross an ABI boundary
compared to the system compiler, as with newer gcc versions on centos7.