### PR TITLE
Output metrics to a single file

### DIFF
--- a/reviewer/app/FragLenFilter.cpp
+++ b/reviewer/app/FragLenFilter.cpp
@@ -30,8 +30,7 @@ static int calcFragLen(const ReadPathAlign& readAlign, const ReadPathAlign& mate
     return std::max(readAlign.end, mateAlign.end) - std::min(readAlign.begin, mateAlign.begin);
 }
 
-FragPathAlignsById
-resolveByFragLen(int meanFragLen, const DiplotypePaths& paths, const PairPathAlignById& pairPathAlignById)
+FragPathAlignsById resolveByFragLen(int meanFragLen, const Diplotype& paths, const PairPathAlignById& pairPathAlignById)
 {
     FragPathAlignsById fragPathAlignsById;
 

--- a/reviewer/app/FragLenFilter.hh
+++ b/reviewer/app/FragLenFilter.hh
@@ -28,4 +28,4 @@
 int getMeanFragLen(const FragById& fragById);
 
 FragPathAlignsById
-resolveByFragLen(int meanFragLen, const DiplotypePaths& paths, const PairPathAlignById& pairPathAlignById);
+resolveByFragLen(int meanFragLen, const Diplotype& paths, const PairPathAlignById& pairPathAlignById);

--- a/reviewer/app/GenotypePaths.cpp
+++ b/reviewer/app/GenotypePaths.cpp
@@ -202,7 +202,7 @@ static vector<NodeVectors> extendDiplotype(const vector<NodeVectors>& genotypes,
     return extendedGenotype;
 }
 
-vector<DiplotypePaths>
+vector<Diplotype>
 getCandidateDiplotypePaths(int meanFragLen, const string& vcfPath, const LocusSpecification& locusSpec)
 {
     auto genotypeNodesByNodeRange = getGenotypeNodesByNodeRange(meanFragLen, vcfPath, locusSpec);
@@ -235,12 +235,12 @@ getCandidateDiplotypePaths(int meanFragLen, const string& vcfPath, const LocusSp
         ++node;
     }
 
-    vector<DiplotypePaths> pathsByDiplotype;
+    vector<Diplotype> pathsByDiplotype;
     const NodeId rightFlankNode = locusSpec.regionGraph().numNodes() - 1;
     const int rightFlankLength = locusSpec.regionGraph().nodeSeq(rightFlankNode).length();
     for (const auto& diplotypeNodes : nodesByDiplotype)
     {
-        DiplotypePaths genotypePaths;
+        Diplotype genotypePaths;
         for (const auto& haplotypeNodes : diplotypeNodes)
         {
             genotypePaths.emplace_back(&locusSpec.regionGraph(), 0, haplotypeNodes, rightFlankLength);

--- a/reviewer/app/GenotypePaths.hh
+++ b/reviewer/app/GenotypePaths.hh
@@ -27,7 +27,7 @@
 
 #include "core/LocusSpecification.hh"
 
-using DiplotypePaths = std::vector<graphtools::Path>;
+using Diplotype = std::vector<graphtools::Path>;
 
 /// Computes all possible diplotype paths at the given locus
 /// \param meanFragLen: Mean fragment length
@@ -40,5 +40,5 @@ using DiplotypePaths = std::vector<graphtools::Path>;
 /// (node 0) and end at the last base of the right flank
 /// (last node)
 ///
-std::vector<DiplotypePaths>
+std::vector<Diplotype>
 getCandidateDiplotypePaths(int meanFragLen, const std::string& vcfPath, const LocusSpecification& locusSpec);

--- a/reviewer/app/Phasing.hh
+++ b/reviewer/app/Phasing.hh
@@ -23,11 +23,10 @@
 #include "app/Aligns.hh"
 #include "app/GenotypePaths.hh"
 
-#include <string>
+#include <utility>
 #include <vector>
 
-#include <boost/optional.hpp>
+using ScoredDiplotype = std::pair<Diplotype, int>;
+using ScoredDiplotypes = std::vector<ScoredDiplotype>;
 
-DiplotypePaths phase(
-    const FragById& fragById, const std::vector<DiplotypePaths>& pathsByGenotype,
-    const boost::optional<std::string>& phasingInfoPath);
+ScoredDiplotypes scoreDiplotypes(const FragById& fragById, const std::vector<Diplotype>& diplotypes);

--- a/reviewer/metrics/Metrics.hh
+++ b/reviewer/metrics/Metrics.hh
@@ -25,7 +25,15 @@
 #include "core/Aligns.hh"
 #include "core/LocusSpecification.hh"
 
-void getMetrics(
+struct Metrics
+{
+    std::string variantId = "NA";
+    std::string genotype = "NA";
+    std::string alleleDepth = "NA";
+};
+
+using MetricsByVariant = std::vector<Metrics>;
+
+MetricsByVariant getMetrics(
     const LocusSpecification& locusSpec, const GraphPaths& paths, const FragById& fragById,
-    const FragAssignment& fragAssignment, const FragPathAlignsById& fragPathAlignsById,
-    const std::string& outputPrefix);
+    const FragAssignment& fragAssignment, const FragPathAlignsById& fragPathAlignsById);


### PR DESCRIPTION
This pull request will:
- Output all metrics into a single file (currently REViewer produces a separate metrics file for each repeat)
- Rename `DiplotypePaths` to `Diplotype`; this change is consistent with the underlying conceptual model where (1) a local haplotype is a graph path and (2) a local diplotype is a pair of paths; the code becomes more readable because collections `DiplotypePaths` can now be called `Diplotypes` instead of harder-to-understand phrases like `DiplotypePathsSet`.