### PR TITLE
Remove fmt library requirement

### DIFF
--- a/reviewer/CMakeLists.txt
+++ b/reviewer/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(LibLZMA REQUIRED)
 find_package(CURL REQUIRED)
 find_package(Catch2 REQUIRED)
 find_package(Threads REQUIRED)
-find_package(fmt REQUIRED)
 find_library(htslib libhts.a)
 find_library(htslib hts)
 
@@ -88,8 +87,7 @@ target_link_libraries(REViewer PUBLIC
         ${CURL_LIBRARIES}
         ZLIB::ZLIB
         BZip2::BZip2
-        Threads::Threads
-        fmt::fmt)
+        Threads::Threads)
 
 
 install(TARGETS REViewer RUNTIME DESTINATION bin)


### PR DESCRIPTION
This pull request will remove the `fmt` library requirement from the build script. This change will resolve a build error reported by some users.