### PR TITLE
Report metrics and phasing information

### DIFF
--- a/reviewer/app/GenotypePaths.cpp
+++ b/reviewer/app/GenotypePaths.cpp
@@ -246,6 +246,8 @@ vector<Diplotype> getCandidateDiplotypes(int meanFragLen, const string& vcfPath,
             diplotype.emplace_back(&locusSpec.regionGraph(), 0, haplotypeNodes, rightFlankLength);
         }
 
+        // The code so far considers diplotypes that differ by the order of constituent haplotypes to be distinct.
+        // To overcome this issue, we enforce a consistent haplotype order.
         if (diplotype.front() < diplotype.back())
         {
             std::iter_swap(diplotype.begin(), diplotype.end() - 1);

--- a/reviewer/app/GenotypePaths.hh
+++ b/reviewer/app/GenotypePaths.hh
@@ -28,6 +28,7 @@
 #include "core/LocusSpecification.hh"
 
 using Diplotype = std::vector<graphtools::Path>;
+std::ostream& operator<<(std::ostream& out, const Diplotype& diplotype);
 
 /// Computes all possible diplotype paths at the given locus
 /// \param meanFragLen: Mean fragment length
@@ -41,4 +42,4 @@ using Diplotype = std::vector<graphtools::Path>;
 /// (last node)
 ///
 std::vector<Diplotype>
-getCandidateDiplotypePaths(int meanFragLen, const std::string& vcfPath, const LocusSpecification& locusSpec);
+getCandidateDiplotypes(int meanFragLen, const std::string& vcfPath, const LocusSpecification& locusSpec);

--- a/reviewer/app/Phasing.cpp
+++ b/reviewer/app/Phasing.cpp
@@ -83,3 +83,5 @@ ScoredDiplotypes scoreDiplotypes(const FragById& fragById, const vector<Diplotyp
     assert(!scoredDiplotypes.empty());
     return scoredDiplotypes;
 }
+
+std::ostream& operator<<(std::ostream& out, const ScoredDiplotype& diplotype) { return out; }

--- a/reviewer/app/REViewer.cpp
+++ b/reviewer/app/REViewer.cpp
@@ -49,7 +49,6 @@ optional<WorkflowArguments> getCommandLineArguments(int argc, char** argv)
             ("catalog", po::value<string>(&args.catalogPath)->required(), "Variant catalog")
             ("locus", po::value<string>(&args.locusId)->required(), "Locus to analyze (or a list of comma-separated loci)")
             ("region-extension-length", po::value<int>(&args.locusExtensionLength)->default_value(1000), "Length of flanking region (must match corresponding ExpansionHunter setting)")
-            ("output-phasing-info", po::bool_switch(&args.outputPhasingInfo), "Output results of the haplotype estimation algorithm")
             ("output-prefix", po::value<string>(&args.outputPrefix)->required(), "Prefix for the output files");
     // clang-format on
 

--- a/reviewer/app/Workflow.cpp
+++ b/reviewer/app/Workflow.cpp
@@ -105,7 +105,6 @@ static LocusResults analyzeLocus(
     auto pathsByDiplotype = getCandidateDiplotypes(meanFragLen, vcfPath, locusSpec);
 
     spdlog::info("Phasing");
-
     auto scoredDiplotypes = scoreDiplotypes(fragById, pathsByDiplotype);
     auto topDiplotype = scoredDiplotypes.front().first; // scoredDiplotypes are sorted
     spdlog::info("Found {} paths defining diplotype", topDiplotype.size());
@@ -156,21 +155,21 @@ std::ofstream initPhasingFile(const std::string& prefix, bool generateOutput)
 {
     if (!generateOutput)
     {
-        std::ofstream phasingInfoFile;
-        phasingInfoFile.setstate(std::ios::failbit);
-        return phasingInfoFile;
+        std::ofstream file;
+        file.setstate(std::ios::failbit);
+        return file;
     }
 
     const auto path = prefix + ".phasing.tsv";
-    std::ofstream phasingInfoFile(path);
-    if (!phasingInfoFile.is_open())
+    std::ofstream file(path);
+    if (!file.is_open())
     {
         throw std::runtime_error("Unable to open " + path);
     }
 
-    phasingInfoFile << "LocusId\tDiplotype\tScore" << std::endl;
+    file << "LocusId\tDiplotype\tScore" << std::endl;
 
-    return phasingInfoFile;
+    return file;
 }
 
 std::ofstream initMetricsFile(const std::string& prefix)

--- a/reviewer/app/Workflow.cpp
+++ b/reviewer/app/Workflow.cpp
@@ -151,15 +151,8 @@ vector<string> getLocusIds(const RegionCatalog& catalog, const string& encoding)
     return locusIds;
 }
 
-std::ofstream initPhasingFile(const std::string& prefix, bool generateOutput)
+std::ofstream initPhasingFile(const std::string& prefix)
 {
-    if (!generateOutput)
-    {
-        std::ofstream file;
-        file.setstate(std::ios::failbit);
-        return file;
-    }
-
     const auto path = prefix + ".phasing.tsv";
     std::ofstream file(path);
     if (!file.is_open())
@@ -191,7 +184,7 @@ int runWorkflow(const WorkflowArguments& args)
     Reference reference(args.referencePath);
     auto locusCatalog = loadLocusCatalogFromDisk(args.catalogPath, reference, args.locusExtensionLength);
     auto locusIds = getLocusIds(locusCatalog, args.locusId);
-    auto phasingFile = initPhasingFile(args.outputPrefix, args.outputPhasingInfo);
+    auto phasingFile = initPhasingFile(args.outputPrefix);
     auto metricsFile = initMetricsFile(args.outputPrefix);
 
     for (const auto& locusId : locusIds)

--- a/reviewer/app/Workflow.hh
+++ b/reviewer/app/Workflow.hh
@@ -34,7 +34,6 @@ struct WorkflowArguments
     std::string locusId;
     std::string outputPrefix;
     int locusExtensionLength;
-    bool outputPhasingInfo;
 };
 
 int runWorkflow(const WorkflowArguments& args);

--- a/reviewer/app/Workflow.hh
+++ b/reviewer/app/Workflow.hh
@@ -20,7 +20,10 @@
 
 #pragma once
 
+#include <fstream>
 #include <string>
+
+#include "app/CatalogLoading.hh"
 
 struct WorkflowArguments
 {

--- a/reviewer/metrics/Metrics.cpp
+++ b/reviewer/metrics/Metrics.cpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <map>
-#include <sstream>
 #include <vector>
 
 using graphtools::NodeId;
@@ -127,24 +126,6 @@ static map<string, vector<double>> getGenotypeDepths(
     return genotypeDepths;
 }
 
-template <typename T> static string encode(const vector<T>& depths)
-{
-    std::ostringstream encoding;
-    encoding.precision(2);
-    encoding << std::fixed;
-
-    for (auto depth : depths)
-    {
-        if (encoding.tellp())
-        {
-            encoding << "/";
-        }
-        encoding << depth;
-    }
-
-    return encoding.str();
-}
-
 MetricsByVariant getMetrics(
     const LocusSpecification& locusSpec, const GraphPaths& paths, const FragById& fragById,
     const FragAssignment& fragAssignment, const FragPathAlignsById& fragPathAlignsById)
@@ -155,13 +136,10 @@ MetricsByVariant getMetrics(
 
     for (const auto& variantSpec : locusSpec.variantSpecs())
     {
-        const auto genotypeEncoding = encode(genotypes.at(variantSpec.id()));
-        const auto depthsEncoding = encode(genotypeDepths.at(variantSpec.id()));
-
         Metrics metrics;
         metrics.variantId = variantSpec.id();
-        metrics.genotype = genotypeEncoding;
-        metrics.alleleDepth = depthsEncoding;
+        metrics.genotype = genotypes.at(variantSpec.id());
+        metrics.alleleDepth = genotypeDepths.at(variantSpec.id());
 
         metricsByVariant.push_back(metrics);
     }

--- a/reviewer/metrics/Metrics.hh
+++ b/reviewer/metrics/Metrics.hh
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <ostream>
 #include <string>
 #include <vector>
 

--- a/reviewer/metrics/Metrics.hh
+++ b/reviewer/metrics/Metrics.hh
@@ -20,7 +20,9 @@
 
 #pragma once
 
+#include <ostream>
 #include <string>
+#include <vector>
 
 #include "core/Aligns.hh"
 #include "core/LocusSpecification.hh"
@@ -28,8 +30,8 @@
 struct Metrics
 {
     std::string variantId = "NA";
-    std::string genotype = "NA";
-    std::string alleleDepth = "NA";
+    std::vector<int> genotype;
+    std::vector<double> alleleDepth;
 };
 
 using MetricsByVariant = std::vector<Metrics>;


### PR DESCRIPTION
This pull request will:
- Change metrics file format to TSV
- Output optional phasing information into a single file (rather than creating a separate file for each repeat) 
- Clean up `Workflow.cpp`
- Propagate `DiplotypePaths` to `Diplotype` name change

Example of a metrics file:
```tsv
VariantId	Genotype	AlleleDepth
DMPK	13/15	28.38/27.84
ATXN3	20/20	20.42/22.72
HTT	14/17	21.00/16.35
HTT_CCG	12/9	17.89/20.74
```

Example of a file with phasing information:
```tsv
LocusId	Diplotype	Score
DMPK	(LF)(CAG){13}(RF)/(LF)(CAG){15}(RF)	700671
ATXN3	(LF)(GCT){20}(RF)/(LF)(GCT){20}(RF)	716594
HTT	(LF)(CAG){14}(CAACAG)(CCG){12}(RF)/(LF)(CAG){17}(CAACAG)(CCG){9}(RF)	646181
HTT	(LF)(CAG){14}(CAACAG)(CCG){9}(RF)/(LF)(CAG){17}(CAACAG)(CCG){12}(RF)	645285
```
Here `(LF)` and `(RF)` correspond to the left and the right flanks respectively; `(CAG){14}` corresponds to 14 copies of CAG; `Score` is the cumulative alignment score of all reads to the corresponding diplotype. 

**Notes**
- The output of phasing information is turned off by setting the output file stream into the error state; data written to such streams are discarded. Are there any reasons to avoid this approach? 
  ```c++
  std::ofstream file;
  file.setstate(std::ios::failbit);
  ```
- I am working on a draft of metrics/phasing documentation 😃 