### PR TITLE
fix gcc 11 build break

### DIFF
--- a/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp
+++ b/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp
@@ -22,6 +22,7 @@
 #include "graphutils/PairHashing.hh"
 
 #include <cassert>
+#include <limits>
 
 namespace graphtools
 {


### PR DESCRIPTION
https://www.gnu.org/software/gcc/gcc-11/porting_to.html#header-dep-changes

error msg:
```
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp: In constructor 'graphtools::GraphCoordinates::GraphCoordinatesImpl::GraphCoordinatesImpl(const graphtools::Graph*)':
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:52:40: error: 'numeric_limits' is not a member of 'std'
   52 |                 size_t min_dist = std::numeric_limits<size_t>::max();
      |                                        ^~~~~~~~~~~~~~
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:52:61: error: expected primary-expression before '>' token
   52 |                 size_t min_dist = std::numeric_limits<size_t>::max();
      |                                                             ^
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:52:64: error: '::max' has not been declared; did you mean 'std::max'?
   52 |                 size_t min_dist = std::numeric_limits<size_t>::max();
      |                                                                ^~~
      |                                                                std::max
In file included from C:/msys64/mingw64/include/c++/11.2.0/algorithm:62,
                 from C:/msys64/mingw64/include/c++/11.2.0/regex:38,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/include/graphalign/GraphAlignment.hh:28,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/include/graphcore/GraphCoordinates.hh:23,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:21:
C:/msys64/mingw64/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:67:38: error: 'numeric_limits' is not a member of 'std'
   67 |                 if (min_dist != std::numeric_limits<size_t>::max())
      |                                      ^~~~~~~~~~~~~~
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:67:59: error: expected primary-expression before '>' token
   67 |                 if (min_dist != std::numeric_limits<size_t>::max())
      |                                                           ^
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:67:62: error: '::max' has not been declared; did you mean 'std::max'?
   67 |                 if (min_dist != std::numeric_limits<size_t>::max())
      |                                                              ^~~
      |                                                              std::max
In file included from C:/msys64/mingw64/include/c++/11.2.0/algorithm:62,
                 from C:/msys64/mingw64/include/c++/11.2.0/regex:38,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/include/graphalign/GraphAlignment.hh:28,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/include/graphcore/GraphCoordinates.hh:23,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:21:
C:/msys64/mingw64/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp: In member function 'uint64_t graphtools::GraphCoordinates::distance(uint64_t, uint64_t) const':
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:197:28: error: 'numeric_limits' is not a member of 'std'
  197 |     uint64_t result = std::numeric_limits<uint64_t>::max();
      |                            ^~~~~~~~~~~~~~
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:197:51: error: expected primary-expression before '>' token
  197 |     uint64_t result = std::numeric_limits<uint64_t>::max();
      |                                                   ^
E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:197:54: error: '::max' has not been declared; did you mean 'std::max'?
  197 |     uint64_t result = std::numeric_limits<uint64_t>::max();
      |                                                      ^~~
      |                                                      std::max
In file included from C:/msys64/mingw64/include/c++/11.2.0/algorithm:62,
                 from C:/msys64/mingw64/include/c++/11.2.0/regex:38,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/include/graphalign/GraphAlignment.hh:28,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/include/graphcore/GraphCoordinates.hh:23,
                 from E:/Source/Repos/REViewer/reviewer/thirdparty/graph-tools/src/graphcore/GraphCoordinates.cpp:21:
C:/msys64/mingw64/include/c++/11.2.0/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
make[5]: *** [thirdparty/graph-tools/CMakeFiles/graphtools.dir/build.make:286: thirdparty/graph-tools/CMakeFiles/graphtools.dir/src/graphcore/GraphCoordinates.cpp.obj] Error 1
make[5]: Leaving directory '/e/Source/Repos/REViewer/build/reviewer-prefix/src/reviewer-build'
make[4]: *** [CMakeFiles/Makefile2:244: thirdparty/graph-tools/CMakeFiles/graphtools.dir/all] Error 2
make[4]: Leaving directory '/e/Source/Repos/REViewer/build/reviewer-prefix/src/reviewer-build'
make[3]: *** [Makefile:136: all] Error 2
make[3]: Leaving directory '/e/Source/Repos/REViewer/build/reviewer-prefix/src/reviewer-build'
make[2]: *** [CMakeFiles/reviewer.dir/build.make:86: reviewer-prefix/src/reviewer-stamp/reviewer-build] Error 2
make[2]: Leaving directory '/e/Source/Repos/REViewer/build'
make[1]: *** [CMakeFiles/Makefile2:169: CMakeFiles/reviewer.dir/all] Error 2
make[1]: Leaving directory '/e/Source/Repos/REViewer/build'
make: *** [Makefile:91: all] Error 2
```
